### PR TITLE
Matching when ending with 'py'

### DIFF
--- a/scrape-search-engines.sh
+++ b/scrape-search-engines.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
-lynx -dump https://github.com/qbittorrent/search-plugins/wiki/Unofficial-search-plugins#plugins-for-public-sites | awk '/py/{print $2}' > qbittorrent-search-engine.txt && wget -i qbittorrent-search-engine.txt
+lynx -dump https://github.com/qbittorrent/search-plugins/wiki/Unofficial-search-plugins#plugins-for-public-sites | awk '/py$/{print $2}' > qbittorrent-search-engine.txt && wget -i qbittorrent-search-engine.txt
 


### PR DESCRIPTION
I added the end anchor $ after '/py so it will only match files that end with 'py'. Otherwise it will also download the .gif files from the download button.